### PR TITLE
Remember selected bestuurseenheid

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -1,9 +1,6 @@
 import Controller from '@ember/controller';
 
 export default Controller.extend({
-  bestuurseenheidId: '',
-  bestuurseenheid: null,
-
   actions: {
     setBestuurseenheid(value) {
       this.set('bestuurseenheid', value);

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -7,7 +7,7 @@ export default Route.extend({
 
   model(params) {
     return {
-      id: params.bestuurseenheidId ? params.bestuurseenheidId : ''
+      id: params.bestuurseenheidId || ''
     };
   }
 });

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -6,8 +6,12 @@ export default Route.extend({
   },
 
   model(params) {
-    return {
-      id: params.bestuurseenheidId || ''
-    };
+    this.set('id', params.bestuurseenheidId || '');
+  },
+
+  async setupController(controller, model) {
+    if (this.id != '') {
+      controller.set('bestuurseenheid', await this.store.findRecord('bestuurseenheid', this.id));
+    }
   }
 });

--- a/app/templates/bestuurseenheid/functionarissen.hbs
+++ b/app/templates/bestuurseenheid/functionarissen.hbs
@@ -2,10 +2,8 @@
   <div class="u-padding--top--tiny">
     <div class="grid">
       <div class="col--6-12">
-        <a class="link--icon">
-          {{#link-to "index"}}
-            <small><i  class="vi-arrow vi-u-180deg vi"></i> Terug naar zoeken</small>
-          {{/link-to}}
+        <a class="link--icon" href="/?bestuurseenheidId={{bestuurseenheid.id}}">
+          <small><i  class="vi-arrow vi-u-180deg vi"></i> Terug naar zoeken</small>
         </a>
       </div>
     </div>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -10,7 +10,7 @@
         <h3 class="h5 u-spacer--tiny">Kies een bestuurseenheid</h3>
         <p class="small u-spacer--tiny">Zoals een gemeentebestuur, autonoom gemeentebedrijf, OCMW-vereniging, intergemeentelijk samenwerkingsverband (IGS), provinciebestuur of autonoom provinciebedrijf (APB)</p>
         {{select-bestuurseenheid
-          value=model.id
+          value=bestuurseenheid.id
           onSelectionChange=(action "setBestuurseenheid")
           class="u-spacer--tiny ember-power-select--large"
         }}


### PR DESCRIPTION
If user navigates to the details page then clicks on the _Terug naar zoeken_ link to go back to the first page, the current bestuurseenheid will still be selected. This is the expected behavior. But, if the user  **does a page refresh before clicking the back link**, then that selection will be lost. This PR seeks to address this issue.