### PR TITLE
Allow users to load more search results

### DIFF
--- a/app/components/select-bestuurseenheid.js
+++ b/app/components/select-bestuurseenheid.js
@@ -3,40 +3,58 @@ import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { timeout } from 'ember-concurrency';
-import { task, restartableTask } from 'ember-concurrency-decorators';
+import { dropTask, task, restartableTask } from 'ember-concurrency-decorators';
 
 export default class SelectBestuurseenheid extends Component {
   @service store;
   @tracked selected = null;
-  @tracked options;
+  @tracked exampleOptions = [];
+  @tracked searchData;
 
   constructor() {
     super(...arguments);
     this.loadData.perform();
   }
 
-  @task
-  * loadData() {
-    const options = yield this.store.query('bestuurseenheid', {
-      sort: 'naam',
-      include: 'classificatie'
-    });
-    this.options = options;
-    this.updateSelectedValue();
+  get isSearching() {
+    return Boolean(this.searchData);
   }
 
-  
-  value = null; // id of selected record
-  onSelectionChange = null;
+  get options() {
+    return this.isSearching ? this.searchData.results : this.exampleOptions;
+  }
+
+  @task
+  *loadData() {
+    this.exampleOptions = yield this.fetchBestuurseenheden();
+    this.updateSelectedValue();
+  }
 
   @restartableTask
   *search(term) {
     yield timeout(600);
-    return this.store.query('bestuurseenheid', {
-      sort: 'naam',
-      include: 'classificatie',
-      filter: term
+
+    let result = yield this.fetchBestuurseenheden({
+      filter: term,
     });
+
+    this.searchData = new SearchData({
+      totalResultAmount: result.meta.count,
+      searchTerm: term,
+      results: result.toArray(),
+    });
+  }
+
+  @dropTask
+  *loadMoreSearchResults() {
+    if (this.isSearching) {
+      let results = yield this.fetchBestuurseenheden({
+        filter: this.searchData.searchTerm,
+        "page[number]": ++this.searchData.currentPage,
+      });
+
+      this.searchData.addSearchResults(results.toArray());
+    }
   }
 
   @action
@@ -54,4 +72,38 @@ export default class SelectBestuurseenheid extends Component {
     this.args.onSelectionChange(selected);
   }
 
+  @action
+  registerAPI(api) {
+    if (!api.searchText && this.searchData) {
+      this.searchData = null;
+    }
+  }
+
+  async fetchBestuurseenheden(searchQuery = {}) {
+    return this.store.query("bestuurseenheid", {
+      sort: "naam",
+      include: "classificatie",
+      "page[number]": 0,
+      ...searchQuery,
+    });
+  }
+}
+
+class SearchData {
+  @tracked results = [];
+  currentPage = 0;
+
+  constructor({ totalResultAmount, searchTerm, results }) {
+    this.totalResultAmount = totalResultAmount;
+    this.searchTerm = searchTerm;
+    this.results = results;
+  }
+
+  get canLoadMoreSearchResults() {
+    return this.totalResultAmount > this.results.length;
+  }
+
+  addSearchResults(newResults = []) {
+    this.results = [...this.results, ...newResults];
+  }
 }

--- a/app/components/select/infinite-options.hbs
+++ b/app/components/select/infinite-options.hbs
@@ -1,0 +1,29 @@
+<div class="select-infinite-options">
+  <PowerSelect::Options
+    @loadingMessage={{@loadingMessage}}
+    @select={{@select}}
+    @options={{@options}}
+    @groupIndex=""
+    @optionsComponent={{@optionsComponent}}
+    @extra={{@extra}}
+    @highlightOnHover={{@highlightOnHover}}
+    @groupComponent={{@groupComponent}}
+    ...attributes
+    as |option select|
+  >
+    {{yield option select}}
+  </PowerSelect::Options>
+  {{#if @canLoadMore}}
+    <div class="au-o-box au-o-box--tiny">
+      <AuButton
+        @skin="secondary"
+        @width="block"
+        @loading={{if @isLoadingMore "true"}}
+        @disabled={{if @isLoadingMore "true"}}
+        {{on "click" @loadMore}}
+      >
+        Meer bestuurseenheden laden
+      </AuButton>
+    </div>
+  {{/if}}
+</div>

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -86,6 +86,9 @@
 @import 'ember-power-select';
 @import "ember-appuniversum/p-ember-power-select";
 
+// Project styles
+@import 'project/select-infinite-options';
+
 // UTILITIES
 @import "appuniversum/u-align-text";
 @import "appuniversum/u-headings";

--- a/app/styles/project/_select-infinite-options.scss
+++ b/app/styles/project/_select-infinite-options.scss
@@ -1,0 +1,14 @@
+.select-infinite-options {
+  // Copied from ember-appuniversum: https://github.com/appuniversum/ember-appuniversum/blob/09fbccfa34190ab9552f42572d783d35e6925ad6/app/styles/ember-appuniversum/_p-ember-power-select.scss#L421-L424
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  @if unitless($ember-power-select-line-height) {
+    max-height: #{$ember-power-select-number-of-visible-options * $ember-power-select-line-height}em;
+  } @else {
+    max-height: $ember-power-select-number-of-visible-options * $ember-power-select-line-height;
+  }
+
+  .ember-power-select-options {
+    max-height: none;
+  }
+}

--- a/app/templates/components/select-bestuurseenheid.hbs
+++ b/app/templates/components/select-bestuurseenheid.hbs
@@ -15,6 +15,14 @@
     @selected={{this.selected}}
     @onChange={{this.changeSelected}}
     @noMatchesMessage="Geen resultaten"
+    @loadingMessage="Aan het laden..."
+    @optionsComponent={{component
+      "select/infinite-options"
+      canLoadMore=this.searchData.canLoadMoreSearchResults
+      loadMore=(perform this.loadMoreSearchResults)
+      isLoadingMore=this.loadMoreSearchResults.isRunning
+    }}
+    @registerAPI={{this.registerAPI}}
     @allowClear={{true}}
     as |bestuurseenheid|
   >


### PR DESCRIPTION
The search results are paginated by the server. Before this change not all options would be displayed and there was no option to load more. Some users couldn't find the option they needed and making the search term more specific isn't always possible. For example, searching for `mechelen` wouldn't list the "gemeente" and there is no way to make that search term more specific.

This adds an extra button which users can click to manually load more search results.

![image](https://user-images.githubusercontent.com/3533236/189335810-54446fd7-a7f2-4089-8472-2926930221ae.png)
