### PR TITLE
Fix an issue with the built docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ RUN npm ci
 COPY . .
 RUN npm run build
 
+# install fastboot dependencies
+RUN cd dist && npm install
+
 
 FROM redpencil/fastboot-app-server:1.3.0
 


### PR DESCRIPTION
This fixes some runtime issues when running the FastBoot app. This worked only by accident in older images.